### PR TITLE
Support default value for properties

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -224,7 +224,8 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
         // Field definitions.
         for (f <- r.fields) {
           writeDoc(w, f.doc)
-          w.wl(marshal.fieldType(f.ty) + " " + idCpp.field(f.ident) + ";")
+          val defaultValue = if (f.defaultValue.isEmpty) "" else " = " + f.defaultValue
+          w.wl(marshal.fieldType(f.ty) + " " + idCpp.field(f.ident) + defaultValue + ";")
         }
 
         if (r.derivingTypes.contains(DerivingType.Eq)) {

--- a/src/source/ast.scala
+++ b/src/source/ast.scala
@@ -88,7 +88,7 @@ object Interface {
   case class Method(ident: Ident, params: Seq[Field], ret: Option[TypeRef], doc: Doc, static: Boolean, const: Boolean, lang: Ext)
 }
 
-case class Field(ident: Ident, ty: TypeRef, doc: Doc)
+case class Field(ident: Ident, ty: TypeRef, defaultValue: String, doc: Doc)
 
 case class ProtobufMessage(cpp: ProtobufMessage.Cpp, java: ProtobufMessage.Java, objc: Option[ProtobufMessage.Objc], ts: Option[ProtobufMessage.Ts]) extends TypeDef
 object ProtobufMessage {

--- a/src/source/parser.scala
+++ b/src/source/parser.scala
@@ -130,8 +130,8 @@ private object IdlParser extends RegexParsers {
       Record(ext, fields, consts, derivingTypes)
     }
   }
-  def field: Parser[Field] = doc ~ ident ~ ":" ~ typeRef ^^ {
-    case doc~ident~_~typeRef => Field(ident, typeRef, doc)
+  def field: Parser[Field] = doc ~ ident ~ ":" ~ typeRef ~ opt("=" ~> defaultValue) ^^ {
+    case doc~ident~_~typeRef~defaultValue => Field(ident, typeRef, defaultValue.getOrElse("").toString, doc)
   }
   def deriving: Parser[Set[DerivingType]] = "deriving" ~> parens(rep1sepend(ident, ",")) ^^ {
     _.map(ident => ident.name match {
@@ -211,6 +211,8 @@ private object IdlParser extends RegexParsers {
 
   // Integer before float for compatibility; ident for enum option
   def value = floatValue | intValue | boolValue | stringValue | enumValue | constRef | compositeValue
+  def anyWord: Parser[String] = ("""\w+::\w+""".r | """\w+\(\)""".r | """\w+""".r)
+  def defaultValue: Parser[String] = anyWord | stringValue
 
   def const: Parser[Const] = doc ~ "const" ~ ident ~ ":" ~ typeRef ~ "=" ~ value ^^ {
     case doc~_~ident~_~typeRef~_~value => Const(ident, typeRef, value, doc)


### PR DESCRIPTION
Fields in Record can now have a default value:
```
TestViewModel = record {
    text: string = "default string";
    count: i32 = 0;
    letterCase: LetterCase = LetterCase::Default;
    label: Label = Label();
}
```

Will generate something like this:
```
// AUTOGENERATED FILE - DO NOT MODIFY!
// This file was generated by Djinni from ViewModels.djinni

#pragma once

#include "LabelViewModel.h"
#include "LetterCaseViewModel.h"
#include <cstdint>
#include <string>
#include <utility>

namespace transitLib::viewModel {

struct TestViewModel final {
    std::string text = "default string";
    int32_t count = 0;
    LetterCase letterCase = LetterCase::Default;
    Label label = Label();
};

} // namespace transitLib::viewModel
```
