### PR TITLE
Support multiple header imports in .yaml

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -46,7 +46,7 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
     }
     def find(m: Meta, forwardDeclareOnly : Boolean) = {
       for(r <- marshal.hppReferences(m, name, forwardDeclareOnly)) r match {
-        case ImportRef(arg) => hpp.add("#include " + arg)
+        case ImportRef(arg) => arg.split(",").foreach((part) => hpp.add("#include " + part.trim()))        
         case DeclRef(decl, Some(spec.cppNamespace)) => hppFwds.add(decl)
         case DeclRef(_, _) =>
       }
@@ -225,8 +225,6 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
     if (r.ext.cpp) {
       refs.cpp.add("#include "+q(spec.cppExtendedRecordIncludePrefix + spec.cppFileIdentStyle(ident) + "." + spec.cppHeaderExt))
     }
-
-
 
     // C++ Header
     def writeCppPrototype(w: IndentWriter) {

--- a/test-suite/djinni/vendor/third-party/date.yaml
+++ b/test-suite/djinni/vendor/third-party/date.yaml
@@ -6,7 +6,7 @@ params: []
 prefix: ''
 cpp:
   typename: 'std::chrono::system_clock::time_point'
-  header: '<chrono>'
+  header: '<chrono>, <memory>'
   byValue: true
 objc:
   typename: 'NSDate'

--- a/test-suite/generated-src/cpp/date_record.hpp
+++ b/test-suite/generated-src/cpp/date_record.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <chrono>
+#include <memory>
 #include <utility>
 
 namespace testsuite {

--- a/test-suite/generated-src/cpp/map_date_record.hpp
+++ b/test-suite/generated-src/cpp/map_date_record.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <chrono>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/AccessFlags.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/AccessFlags.java
@@ -7,14 +7,14 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 public enum AccessFlags {
-    OWNER_READ,
-    OWNER_WRITE,
-    OWNER_EXECUTE,
-    GROUP_READ,
-    GROUP_WRITE,
-    GROUP_EXECUTE,
-    SYSTEM_READ,
-    SYSTEM_WRITE,
-    SYSTEM_EXECUTE,
+    OwnerRead,
+    OwnerWrite,
+    OwnerExecute,
+    GroupRead,
+    GroupWrite,
+    GroupExecute,
+    SystemRead,
+    SystemWrite,
+    SystemExecute,
     ;
 }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/Color.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/Color.java
@@ -7,17 +7,17 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 public enum Color {
-    RED,
-    ORANGE,
-    YELLOW,
-    GREEN,
-    BLUE,
+    Red,
+    Orange,
+    Yellow,
+    Green,
+    Blue,
     /**
      * "It is customary to list indigo as a color lying between blue and violet, but it has
      * never seemed to me that indigo is worth the dignity of being considered a separate
      * color. To my eyes it seems merely deep blue." --Isaac Asimov
      */
-    INDIGO,
-    VIOLET,
+    Indigo,
+    Violet,
     ;
 }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantEnum.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantEnum.java
@@ -8,7 +8,7 @@ import javax.annotation.Nonnull;
 
 /** enum for use in constants */
 public enum ConstantEnum {
-    SOME_VALUE,
-    SOME_OTHER_VALUE,
+    SomeValue,
+    SomeOtherValue,
     ;
 }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantInterfaceWithEnum.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantInterfaceWithEnum.java
@@ -11,7 +11,7 @@ import javax.annotation.Nonnull;
 /** Interface containing enum constant */
 public abstract class ConstantInterfaceWithEnum {
     @Nonnull
-    public static final ConstantEnum CONST_ENUM = ConstantEnum.SOME_VALUE;
+    public static final ConstantEnum CONST_ENUM = ConstantEnum.SomeValue;
 
 
     public static final class CppProxy extends ConstantInterfaceWithEnum

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantWithEnum.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantWithEnum.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 public class ConstantWithEnum {
 
     @Nonnull
-    public static final ConstantEnum CONST_ENUM = ConstantEnum.SOME_VALUE;
+    public static final ConstantEnum CONST_ENUM = ConstantEnum.SomeValue;
 
 
     public ConstantWithEnum(

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/TestIdentEnumNative.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/TestIdentEnumNative.java
@@ -7,8 +7,8 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 public enum TestIdentEnumNative {
-    SNAKE_ENUM,
+    SnakeEnum,
     /** Should become CapsEnum in objective-c, but stay the same in Java/C++ */
-    CAPS_ENUM,
+    CAPSENUM,
     ;
 }

--- a/test-suite/generated-src/kotlin/com/dropbox/djinni/test/AccessFlags.kt
+++ b/test-suite/generated-src/kotlin/com/dropbox/djinni/test/AccessFlags.kt
@@ -4,13 +4,13 @@
 package com.dropbox.djinni.test
 
 enum class AccessFlags {
-    OWNER_READ,
-    OWNER_WRITE,
-    OWNER_EXECUTE,
-    GROUP_READ,
-    GROUP_WRITE,
-    GROUP_EXECUTE,
-    SYSTEM_READ,
-    SYSTEM_WRITE,
-    SYSTEM_EXECUTE,
+    OwnerRead,
+    OwnerWrite,
+    OwnerExecute,
+    GroupRead,
+    GroupWrite,
+    GroupExecute,
+    SystemRead,
+    SystemWrite,
+    SystemExecute,
 }

--- a/test-suite/generated-src/kotlin/com/dropbox/djinni/test/Color.kt
+++ b/test-suite/generated-src/kotlin/com/dropbox/djinni/test/Color.kt
@@ -4,16 +4,16 @@
 package com.dropbox.djinni.test
 
 enum class Color {
-    RED,
-    ORANGE,
-    YELLOW,
-    GREEN,
-    BLUE,
+    Red,
+    Orange,
+    Yellow,
+    Green,
+    Blue,
     /**
      * "It is customary to list indigo as a color lying between blue and violet, but it has
      * never seemed to me that indigo is worth the dignity of being considered a separate
      * color. To my eyes it seems merely deep blue." --Isaac Asimov
      */
-    INDIGO,
-    VIOLET,
+    Indigo,
+    Violet,
 }

--- a/test-suite/generated-src/kotlin/com/dropbox/djinni/test/ConstantEnum.kt
+++ b/test-suite/generated-src/kotlin/com/dropbox/djinni/test/ConstantEnum.kt
@@ -5,6 +5,6 @@ package com.dropbox.djinni.test
 
 /** enum for use in constants */
 enum class ConstantEnum {
-    SOME_VALUE,
-    SOME_OTHER_VALUE,
+    SomeValue,
+    SomeOtherValue,
 }

--- a/test-suite/generated-src/kotlin/com/dropbox/djinni/test/ConstantInterfaceWithEnum.kt
+++ b/test-suite/generated-src/kotlin/com/dropbox/djinni/test/ConstantInterfaceWithEnum.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 /** Interface containing enum constant */
 abstract class ConstantInterfaceWithEnum {
     companion object {
-        val CONST_ENUM: ConstantEnum = ConstantEnum.SOME_VALUE
+        val CONST_ENUM: ConstantEnum = ConstantEnum.SomeValue
     }
 
     class CppProxy(private val nativeRef: Long) : ConstantInterfaceWithEnum() {

--- a/test-suite/generated-src/kotlin/com/dropbox/djinni/test/ConstantWithEnum.kt
+++ b/test-suite/generated-src/kotlin/com/dropbox/djinni/test/ConstantWithEnum.kt
@@ -6,7 +6,7 @@ package com.dropbox.djinni.test
 /** Record containing enum constant */
 open class ConstantWithEnum {
     companion object {
-        val CONST_ENUM: ConstantEnum = ConstantEnum.SOME_VALUE
+        val CONST_ENUM: ConstantEnum = ConstantEnum.SomeValue
     }
 
     override fun toString(): String  {

--- a/test-suite/generated-src/kotlin/com/dropbox/djinni/test/TestIdentEnumNative.kt
+++ b/test-suite/generated-src/kotlin/com/dropbox/djinni/test/TestIdentEnumNative.kt
@@ -4,7 +4,7 @@
 package com.dropbox.djinni.test
 
 enum class TestIdentEnumNative {
-    SNAKE_ENUM,
+    SnakeEnum,
     /** Should become CapsEnum in objective-c, but stay the same in Java/C++ */
-    CAPS_ENUM,
+    CAPSENUM,
 }


### PR DESCRIPTION
## Story
https://app.shortcut.com/transit/story/122509/modifiy-djinni-parser-to-include-memory-when-using-shared-ptr

## Context
We can only add a single header inside a `.yaml`, this is currently an issue in transitLib CI because we don't import `<memory>` when using `shared_ptr`. Ideally we would automatically include the necessary libraries but since shared_ptr is a bit hacked, it would be complicated. At least we can manually add the import now using `","` separator

## What I did
Support `","` in the parser for cpp header inside a `.yaml` file (see `date.yaml`)