### PR TITLE
Add equal operator modifier for objc generator

### DIFF
--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -365,7 +365,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
                 }
                 case e: MExtern => e.defType match {
                   case DRecord => if(e.objc.pointer) {
-                      w.w(s"[self.${idObjc.field(f.ident)} isEqual:typedOther.${idObjc.field(f.ident)}]")
+                      w.w(s"[self.${idObjc.field(f.ident)} ${e.objc.equal}:typedOther.${idObjc.field(f.ident)}]")                    
                     } else {
                       w.w(s"self.${idObjc.field(f.ident)} == typedOther.${idObjc.field(f.ident)}")
                     }

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -365,7 +365,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
                 }
                 case e: MExtern => e.defType match {
                   case DRecord => if(e.objc.pointer) {
-                      w.w(s"[self.${idObjc.field(f.ident)} ${e.objc.equal}:typedOther.${idObjc.field(f.ident)}]")                    
+                      w.w(s"[self.${idObjc.field(f.ident)} ${e.objc.equal}typedOther.${idObjc.field(f.ident)}]")
                     } else {
                       w.w(s"self.${idObjc.field(f.ident)} == typedOther.${idObjc.field(f.ident)}")
                     }

--- a/src/source/YamlGenerator.scala
+++ b/src/source/YamlGenerator.scala
@@ -254,6 +254,7 @@ object YamlGenerator {
       nested(td, "objc")("pointer").asInstanceOf[Boolean],
       getOptionalField(td, "objc", "generic", false),
       nested(td, "objc")("hash").toString,
+      getOptionalField(td, "objc", "equal", "isEqual"),
       getOptionalField(td, "objc", "protocol", false)),
     MExtern.Objcpp(
       nested(td, "objcpp")("translator").toString,

--- a/src/source/YamlGenerator.scala
+++ b/src/source/YamlGenerator.scala
@@ -254,7 +254,7 @@ object YamlGenerator {
       nested(td, "objc")("pointer").asInstanceOf[Boolean],
       getOptionalField(td, "objc", "generic", false),
       nested(td, "objc")("hash").toString,
-      getOptionalField(td, "objc", "equal", "isEqual"),
+      getOptionalField(td, "objc", "equal", "isEqual:"),
       getOptionalField(td, "objc", "protocol", false)),
     MExtern.Objcpp(
       nested(td, "objcpp")("translator").toString,

--- a/src/source/meta.scala
+++ b/src/source/meta.scala
@@ -52,7 +52,7 @@ object MExtern {
     pointer: Boolean, // True to construct pointer types and make it eligible for "nonnull" qualifier. Only used for "record" types.
     generic: Boolean, // Set to false to exclude type arguments from the ObjC class. This is should be true by default. Useful if template arguments are only used in C++.
     hash: String, // A well-formed expression to get the hash value. Must be a format string with a single "%s" placeholder. Only used for "record" types with "eq" deriving when needed.
-    equal: String, // Set equal operator. E.i: .isEqual for default operator
+    equal: String, // Set equal operator. E.i: .isEqual: for default operator
     protocol: Boolean
   )
   case class Objcpp(

--- a/src/source/meta.scala
+++ b/src/source/meta.scala
@@ -52,6 +52,7 @@ object MExtern {
     pointer: Boolean, // True to construct pointer types and make it eligible for "nonnull" qualifier. Only used for "record" types.
     generic: Boolean, // Set to false to exclude type arguments from the ObjC class. This is should be true by default. Useful if template arguments are only used in C++.
     hash: String, // A well-formed expression to get the hash value. Must be a format string with a single "%s" placeholder. Only used for "record" types with "eq" deriving when needed.
+    equal: String, // Set equal operator. E.i: .isEqual for default operator
     protocol: Boolean
   )
   case class Objcpp(

--- a/test-suite/djinni/vendor/third-party/date.yaml
+++ b/test-suite/djinni/vendor/third-party/date.yaml
@@ -14,6 +14,7 @@ objc:
   boxed: 'NSDate'
   pointer: true
   hash: '(NSUInteger)%s.timeIntervalSinceReferenceDate'
+  equal: 'isEqualToDate:'
 objcpp:
   translator: '::djinni::Date'
   header: '"DJIMarshal+Private.h"'

--- a/test-suite/generated-src/objc/DBDateRecord.mm
+++ b/test-suite/generated-src/objc/DBDateRecord.mm
@@ -25,7 +25,7 @@
         return NO;
     }
     DBDateRecord *typedOther = (DBDateRecord *)other;
-    return [self.createdAt isEqual:typedOther.createdAt];
+    return [self.createdAt isEqualToDate:typedOther.createdAt];
 }
 
 - (NSUInteger)hash


### PR DESCRIPTION
## Story

https://app.shortcut.com/transit/story/125961/use-isequaltocolor-operator-in-djinni-generated-objc-view-model

## Context

We had an issue when comparing view models using UIColor because djinni would default to `isEqual:`. This operator doesn't work and have to use our custom operator `isEqualToColor:`