### PR TITLE
fix issue in recursive method in order to get all super fields in object

### DIFF
--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -465,8 +465,8 @@ abstract class Generator(spec: Spec)
       r.baseRecord match {
         case None => r.fields ++ fields
         case Some(value) => {
-          val baseRecord = getSuperRecord(idl, r).get
-          superFieldsAccumulator(baseRecord.record, r.fields)
+          val superRecord = getSuperRecord(idl, r).get
+          superFieldsAccumulator(superRecord.record, r.fields ++ fields)
         }
       }
     }


### PR DESCRIPTION
# Problem explanation

`collectSuperFields()` is a recursive method which was sometimes not returning the array of collected fields if the record had a parent. 

