### PR TITLE
manage hash properly for f32 and f64 in Obj-C

### DIFF
--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -393,7 +393,17 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
                       w.w(s"(NSUInteger)self.${idObjc.field(f.ident)}")
                     case _ => w.w(s"self.${idObjc.field(f.ident)}.hash")
                   }
-                case t: MPrimitive => w.w(s"(NSUInteger)self.${idObjc.field(f.ident)}")
+                case t: MPrimitive => {
+                  if (t.objcName == "float") {
+                    w.w(s"[NSNumber numberWithFloat:self.${idObjc.field(f.ident)}].hash")
+                  }
+                  else if (t.objcName == "double") {
+                    w.w(s"[NSNumber numberWithDouble:self.${idObjc.field(f.ident)}].hash")
+                  }
+                  else {
+                    w.w(s"(NSUInteger)self.${idObjc.field(f.ident)}")
+                  }
+                }
                 case df: MDef => df.defType match {
                   case DEnum => w.w(s"(NSUInteger)self.${idObjc.field(f.ident)}")
                   case _ => w.w(s"self.${idObjc.field(f.ident)}.hash")

--- a/test-suite/generated-src/objc/DBAssortedPrimitives.mm
+++ b/test-suite/generated-src/objc/DBAssortedPrimitives.mm
@@ -101,8 +101,8 @@
             (NSUInteger)self.sixteen ^
             (NSUInteger)self.thirtytwo ^
             (NSUInteger)self.sixtyfour ^
-            (NSUInteger)self.fthirtytwo ^
-            (NSUInteger)self.fsixtyfour ^
+            [NSNumber numberWithFloat:self.fthirtytwo].hash ^
+            [NSNumber numberWithDouble:self.fsixtyfour].hash ^
             self.oB.hash ^
             self.oEight.hash ^
             self.oSixteen.hash ^

--- a/test-suite/generated-src/objc/DBRecordWithDerivings.mm
+++ b/test-suite/generated-src/objc/DBRecordWithDerivings.mm
@@ -70,8 +70,8 @@
             (NSUInteger)self.sixteen ^
             (NSUInteger)self.thirtytwo ^
             (NSUInteger)self.sixtyfour ^
-            (NSUInteger)self.fthirtytwo ^
-            (NSUInteger)self.fsixtyfour ^
+            [NSNumber numberWithFloat:self.fthirtytwo].hash ^
+            [NSNumber numberWithDouble:self.fsixtyfour].hash ^
             self.d.hash ^
             self.s.hash;
 }


### PR DESCRIPTION
Djinni was previously casting Float and Long values into NSUInteger for the hash method. This PR is fixing that by managing values properly. 

### Before:
```
- (NSUInteger)hash
{
  return NSStringFromClass([self class]).hash ^
      (NSUInteger)self.latitude ^
      (NSUInteger)self.longitude;
}
```

### After 
```
- (NSUInteger)hash
{
    return NSStringFromClass([self class]).hash ^
            [NSNumber numberWithDouble:self.latitude].hash ^
            [NSNumber numberWithDouble:self.longitude].hash;
}
```