### PR TITLE
Use isEqualToColor when TransitUtilsColor is optional

### DIFF
--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -351,6 +351,16 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
                   f.ty.resolved.args.head.base match {
                     case df: MDef if df.defType == DEnum =>
                       w.w(s"self.${idObjc.field(f.ident)} == typedOther.${idObjc.field(f.ident)}")
+                    case e: MExtern => e.defType match {
+                        case DRecord => if(e.objc.equal.nonEmpty) {
+                             w.w(s"((self.${idObjc.field(f.ident)} == nil && typedOther.${idObjc.field(f.ident)} == nil) || ")
+                             w.w(s"(self.${idObjc.field(f.ident)} != nil && [self.${idObjc.field(f.ident)} ${e.objc.equal}typedOther.${idObjc.field(f.ident)}]))")
+                          } else {
+                             w.w(s"((self.${idObjc.field(f.ident)} == nil && typedOther.${idObjc.field(f.ident)} == nil) || ")
+                             w.w(s"(self.${idObjc.field(f.ident)} != nil && [self.${idObjc.field(f.ident)} isEqual:typedOther.${idObjc.field(f.ident)}]))")
+                          }
+                        case _ => throw new AssertionError("Unreachable")
+                    }
                     case _ =>
                       w.w(s"((self.${idObjc.field(f.ident)} == nil && typedOther.${idObjc.field(f.ident)} == nil) || ")
                       w.w(s"(self.${idObjc.field(f.ident)} != nil && [self.${idObjc.field(f.ident)} isEqual:typedOther.${idObjc.field(f.ident)}]))")


### PR DESCRIPTION
This PR addresses an issue where the comparison method for optional **TransitUtilsColor** instances was inconsistent. In particular, when **TransitUtilsColor** is **optional**, the code now uses **isEqualToColor** for comparisons. This change ensures more reliable and accurate comparisons in scenarios where color instances may be optional.