### PR TITLE
fix issue when subclass has no field in kotlin

### DIFF
--- a/examples/example.djinni
+++ b/examples/example.djinni
@@ -19,5 +19,5 @@ LevelE = record extends LevelD {
 }
 
 LevelF = record extends LevelE {
-    fieldF: string;
+
 }

--- a/examples/generated/android/djinni/java/src/LevelF.kt
+++ b/examples/generated/android/djinni/java/src/LevelF.kt
@@ -11,8 +11,7 @@ data class LevelF(
     override val fieldB: String,
     override val fieldC: String,
     override val fieldD: String,
-    override val fieldE: String,
-    val fieldF: String
+    override val fieldE: String
 ) : LevelE(fieldA, fieldB, fieldC, fieldD, fieldE) {
 
     override fun toString(): String  {
@@ -22,7 +21,6 @@ data class LevelF(
                 "," + "fieldC=" + fieldC +
                 "," + "fieldD=" + fieldD +
                 "," + "fieldE=" + fieldE +
-                "," + "fieldF=" + fieldF +
         "}"
     }
 

--- a/examples/generated/android/jni/NativeLevelF.cpp
+++ b/examples/generated/android/jni/NativeLevelF.cpp
@@ -17,14 +17,13 @@ auto NativeLevelF::fromCpp(JNIEnv* jniEnv, const CppType& c) -> ::djinni::LocalR
                                                            ::djinni::get(::djinni::String::fromCpp(jniEnv, c.fieldB)),
                                                            ::djinni::get(::djinni::String::fromCpp(jniEnv, c.fieldC)),
                                                            ::djinni::get(::djinni::String::fromCpp(jniEnv, c.fieldD)),
-                                                           ::djinni::get(::djinni::String::fromCpp(jniEnv, c.fieldE)),
-                                                           ::djinni::get(::djinni::String::fromCpp(jniEnv, c.fieldF)))};
+                                                           ::djinni::get(::djinni::String::fromCpp(jniEnv, c.fieldE)))};
     ::djinni::jniExceptionCheck(jniEnv);
     return r;
 }
 
 auto NativeLevelF::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
-    ::djinni::JniLocalScope jscope(jniEnv, 7);
+    ::djinni::JniLocalScope jscope(jniEnv, 6);
     assert(j != nullptr);
     const auto& data = ::djinni::JniClass<NativeLevelF>::get();
     ::transitLib::viewModel::LevelF model;
@@ -33,7 +32,6 @@ auto NativeLevelF::toCpp(JNIEnv* jniEnv, JniType j) -> CppType {
     model.fieldC = ::djinni::String::toCpp(jniEnv, (jstring)jniEnv->GetObjectField(j, data.field_fieldC));
     model.fieldD = ::djinni::String::toCpp(jniEnv, (jstring)jniEnv->GetObjectField(j, data.field_fieldD));
     model.fieldE = ::djinni::String::toCpp(jniEnv, (jstring)jniEnv->GetObjectField(j, data.field_fieldE));
-    model.fieldF = ::djinni::String::toCpp(jniEnv, (jstring)jniEnv->GetObjectField(j, data.field_fieldF));
     return model;
 }
 

--- a/examples/generated/android/jni/NativeLevelF.h
+++ b/examples/generated/android/jni/NativeLevelF.h
@@ -25,13 +25,12 @@ private:
     friend ::djinni::JniClass<NativeLevelF>;
 
     const ::djinni::GlobalRef<jclass> clazz { ::djinni::jniFindClass("djinni/java/src/LevelF") };
-    const jmethodID jconstructor { ::djinni::jniGetMethodID(clazz.get(), "<init>", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V") };
+    const jmethodID jconstructor { ::djinni::jniGetMethodID(clazz.get(), "<init>", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V") };
     const jfieldID field_fieldA { ::djinni::jniGetFieldID(clazz.get(), "fieldA", "Ljava/lang/String;") };
     const jfieldID field_fieldB { ::djinni::jniGetFieldID(clazz.get(), "fieldB", "Ljava/lang/String;") };
     const jfieldID field_fieldC { ::djinni::jniGetFieldID(clazz.get(), "fieldC", "Ljava/lang/String;") };
     const jfieldID field_fieldD { ::djinni::jniGetFieldID(clazz.get(), "fieldD", "Ljava/lang/String;") };
     const jfieldID field_fieldE { ::djinni::jniGetFieldID(clazz.get(), "fieldE", "Ljava/lang/String;") };
-    const jfieldID field_fieldF { ::djinni::jniGetFieldID(clazz.get(), "fieldF", "Ljava/lang/String;") };
 };
 
 } // namespace djinni_generated

--- a/examples/generated/cpp/LevelFViewModel.h
+++ b/examples/generated/cpp/LevelFViewModel.h
@@ -4,13 +4,11 @@
 #pragma once
 
 #include "LevelEViewModel.h"
-#include <string>
 #include <utility>
 
 namespace transitLib::viewModel {
 
 struct LevelF : public LevelE {
-    std::string fieldF;
 };
 
 } // namespace transitLib::viewModel

--- a/examples/generated/objc/SPLevelFViewModel+Private.mm
+++ b/examples/generated/objc/SPLevelFViewModel+Private.mm
@@ -16,7 +16,6 @@ auto LevelF::toCpp(ObjcType obj) -> CppType
     model.fieldC = ::djinni::String::toCpp(obj.fieldC);
     model.fieldD = ::djinni::String::toCpp(obj.fieldD);
     model.fieldE = ::djinni::String::toCpp(obj.fieldE);
-    model.fieldF = ::djinni::String::toCpp(obj.fieldF);
     return model;
 }
 
@@ -26,8 +25,7 @@ auto LevelF::fromCpp(const CppType& cpp) -> ObjcType
                                               fieldB:(::djinni::String::fromCpp(cpp.fieldB))
                                               fieldC:(::djinni::String::fromCpp(cpp.fieldC))
                                               fieldD:(::djinni::String::fromCpp(cpp.fieldD))
-                                              fieldE:(::djinni::String::fromCpp(cpp.fieldE))
-                                              fieldF:(::djinni::String::fromCpp(cpp.fieldF))];
+                                              fieldE:(::djinni::String::fromCpp(cpp.fieldE))];
 }
 
 } // namespace djinni_generated

--- a/examples/generated/objc/SPLevelFViewModel.h
+++ b/examples/generated/objc/SPLevelFViewModel.h
@@ -5,21 +5,15 @@
 
 #import "SPLevelEViewModel.h"
 @interface SPLevelFViewModel : SPLevelEViewModel
-- (nonnull instancetype)init NS_UNAVAILABLE;
-+ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithFieldA:(nonnull NSString *)fieldA
                                 fieldB:(nonnull NSString *)fieldB
                                 fieldC:(nonnull NSString *)fieldC
                                 fieldD:(nonnull NSString *)fieldD
-                                fieldE:(nonnull NSString *)fieldE
-                                fieldF:(nonnull NSString *)fieldF NS_DESIGNATED_INITIALIZER;
+                                fieldE:(nonnull NSString *)fieldE NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)LevelFWithFieldA:(nonnull NSString *)fieldA
                                   fieldB:(nonnull NSString *)fieldB
                                   fieldC:(nonnull NSString *)fieldC
                                   fieldD:(nonnull NSString *)fieldD
-                                  fieldE:(nonnull NSString *)fieldE
-                                  fieldF:(nonnull NSString *)fieldF;
-
-@property (nonatomic, readonly, nonnull) NSString * fieldF;
+                                  fieldE:(nonnull NSString *)fieldE;
 
 @end

--- a/examples/generated/objc/SPLevelFViewModel.mm
+++ b/examples/generated/objc/SPLevelFViewModel.mm
@@ -11,7 +11,6 @@
                                 fieldC:(nonnull NSString *)fieldC
                                 fieldD:(nonnull NSString *)fieldD
                                 fieldE:(nonnull NSString *)fieldE
-                                fieldF:(nonnull NSString *)fieldF
 {
     if (self = [super initWithFieldA:fieldA
                               fieldB:fieldB
@@ -19,7 +18,6 @@
                               fieldD:fieldD
                               fieldE:fieldE])
     {
-        _fieldF = [fieldF copy];
     }
     return self;
 }
@@ -29,20 +27,18 @@
                                   fieldC:(nonnull NSString *)fieldC
                                   fieldD:(nonnull NSString *)fieldD
                                   fieldE:(nonnull NSString *)fieldE
-                                  fieldF:(nonnull NSString *)fieldF
 {
     return [[self alloc] initWithFieldA:fieldA
                                  fieldB:fieldB
                                  fieldC:fieldC
                                  fieldD:fieldD
-                                 fieldE:fieldE
-                                 fieldF:fieldF];
+                                 fieldE:fieldE];
 }
 
 #ifndef DJINNI_DISABLE_DESCRIPTION_METHODS
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p fieldA:%@ fieldB:%@ fieldC:%@ fieldD:%@ fieldE:%@ fieldF:%@>", self.class, (void *)self, self.fieldA, self.fieldB, self.fieldC, self.fieldD, self.fieldE, self.fieldF];
+    return [NSString stringWithFormat:@"<%@ %p fieldA:%@ fieldB:%@ fieldC:%@ fieldD:%@ fieldE:%@>", self.class, (void *)self, self.fieldA, self.fieldB, self.fieldC, self.fieldD, self.fieldE];
 }
 
 #endif


### PR DESCRIPTION
There was an issue for Kotlin when a record with a parent had no properties (the kotlin class was empty). 

This problem was not present for C++ or JNI nor Objective-C.