### PR TITLE
Fix NSArray dynamic hash extension

### DIFF
--- a/objc-lib/NSArray+Djinni.mm
+++ b/objc-lib/NSArray+Djinni.mm
@@ -12,7 +12,7 @@
 - (NSUInteger)dynamicHash {
     NSUInteger hash = 0;
     for (NSObject *obj in self) {
-        hash ^= obj.hash;
+        hash += obj.hash;
     }
     return hash;
 }


### PR DESCRIPTION
I really don't know why I used `^=` in the first place, the goal was to create a resulting hash of all the sub view model hashes