### PR TITLE
use dynamic hash with optional lists in Objc

### DIFF
--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -400,6 +400,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
                 case MList | MArray => s"self.${idObjc.field(f.ident)}.dynamicHash"
                 case MOptional =>
                   f.ty.resolved.args.head.base match {
+                    case MList | MArray => s"self.${idObjc.field(f.ident)}.dynamicHash"
                     case df: MDef if df.defType == DEnum =>
                       s"(NSUInteger)self.${idObjc.field(f.ident)}"
                     case e: MExtern => e.defType match {


### PR DESCRIPTION
## Context
In case we use an optional list we want Djinni to generate dynamic hash for Obj-C