### PR TITLE
[Kotlin] - Remove annotation from const koltin generation

### DIFF
--- a/src/source/KotlinGenerator.scala
+++ b/src/source/KotlinGenerator.scala
@@ -97,7 +97,6 @@ class KotlinGenerator(spec: Spec) extends Generator(spec) {
       w.w("companion object").braced {
         for (c <- consts) {
           writeDoc(w, c.doc)
-          javaAnnotationHeader.foreach(w.wl)
           w.w(s"val ${idJava.const(c.ident)}: ${marshal.fieldType(c.ty)} = ")
           writeJavaConst(w, c.ty, c.value)
           w.wl


### PR DESCRIPTION
# Context 

When we were generating const value in koltin the @Immutable annotation was added by default on each value making the code not able to compile. 

I remove the generation of annotation in the case of a const value. 

## Example 
This code in djinni generate

```
TimebarConstants = record {
    const corner_radius_grouped_leg : f32 = 8.0;
    const corner_radius_go_leg : f32 = 4.0;
}
```

Generate 

### Before  change 

@Immutable

```
open class TimebarConstants {
    companion object {
       @Immutable val CORNER_RADIUS_GROUPED_LEG: Float = 8.0F
       @Immutable val CORNER_RADIUS_GO_LEG: Float = 4.0F
    }
```

### After change 
```
@Immutable
open class TimebarConstants {
    companion object {
        val CORNER_RADIUS_GROUPED_LEG: Float = 8.0F
        val CORNER_RADIUS_GO_LEG: Float = 4.0F
    }
```
