### PR TITLE
Fix zlib for Xcode 16.3 command line tool

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,21 @@ http_archive(
     ],
 )
 
+# Use local zlib implementation
+new_local_repository(
+    name = "zlib",
+    path = "/usr",
+    build_file_content = """
+package(default_visibility = ["//visibility:public"])
+cc_library(
+    name = "zlib",
+    srcs = [],
+    linkopts = ["-lz"],
+    hdrs = [],
+)
+"""
+)
+
 rules_scala_version = "c711b4d1f0d1cc386c63ef748c9df14d2f3a187e"
 http_archive(
     name = "io_bazel_rules_scala",


### PR DESCRIPTION
## Context
Djinni doesn't work with Xcode 16.3 command line tool, zlib redefined a macro already existing by the OS (`fdopen`). With incredible logic (Claude 3.7) and through trials and errors (copilot agent), I (AI) managed to successfully fix this issue by simply using local zlib instead.