### PR TITLE
Add partial support for Python, add from_string to C++ enums

### DIFF
--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -36,6 +36,7 @@ object Main {
     var cppOptionalTemplate: String = "std::optional"
     var cppOptionalHeader: String = "<optional>"
     var cppEnumHashWorkaround : Boolean = true
+    var cppEnumFromString : Boolean = true
     var cppNnHeader: Option[String] = None
     var cppNnType: Option[String] = None
     var cppNnCheckExpression: Option[String] = None
@@ -106,6 +107,8 @@ object Main {
     var yamlOutFolder: Option[File] = None
     var yamlOutFile: Option[String] = None
     var yamlPrefix: String = ""
+    var pythonEnumOutFolder: Option[File] = None
+    var pythonIdentStyle = IdentStyle.pythonDefault
 
     val argParser = new scopt.OptionParser[Unit]("djinni") {
 
@@ -169,6 +172,8 @@ object Main {
         .text("The header to use for optional values (default: \"<optional>\")")
       opt[Boolean]("cpp-enum-hash-workaround").valueName("<true/false>").foreach(x => cppEnumHashWorkaround = x)
         .text("Work around LWG-2148 by generating std::hash specializations for C++ enums (default: true)")
+      opt[Boolean]("cpp-enum-from-string").valueName("<true/false>").foreach(x => cppEnumFromString = x)
+        .text("Implement a from_string function for C++ enums (default: true)")
       opt[String]("cpp-nn-header").valueName("<header>").foreach(x => cppNnHeader = Some(x))
         .text("The header to use for non-nullable pointers")
       opt[String]("cpp-nn-type").valueName("<header>").foreach(x => cppNnType = Some(x))
@@ -265,6 +270,9 @@ object Main {
         .text("If specified all types are merged into a single YAML file instead of generating one file per type (relative to --yaml-out).")
       opt[String]("yaml-prefix").valueName("<pre>").foreach(yamlPrefix = _)
         .text("The prefix to add to type names stored in YAML files (default: \"\").")
+      note("")
+      opt[File]("python-enum-out").valueName("<out-folder>").foreach(x => pythonEnumOutFolder = Some(x))
+        .text("The output folder for Python enum files (Generator disabled if unspecified).")
       note("")
       opt[File]("list-in-files").valueName("<list-in-files>").foreach(x => inFileListPath = Some(x))
         .text("Optional file in which to write the list of input files parsed.")
@@ -396,6 +404,7 @@ object Main {
       cppOptionalTemplate,
       cppOptionalHeader,
       cppEnumHashWorkaround,
+      cppEnumFromString,
       cppNnHeader,
       cppNnType,
       cppNnCheckExpression,
@@ -449,6 +458,8 @@ object Main {
       yamlOutFolder,
       yamlOutFile,
       yamlPrefix,
+      pythonEnumOutFolder,
+      pythonIdentStyle,
       idlFile.getName.stripSuffix(".djinni"))
 
     try {

--- a/src/source/Marshal.scala
+++ b/src/source/Marshal.scala
@@ -39,6 +39,7 @@ abstract class Marshal(spec: Spec) {
 
   implicit def identToString(ident: Ident): String = ident.name
   protected val idCpp = spec.cppIdentStyle
+  protected val idPython = spec.pythonIdentStyle
   protected val idJava = spec.javaIdentStyle
   protected val idObjc = spec.objcIdentStyle
 

--- a/src/source/PythonEnumGenerator.scala
+++ b/src/source/PythonEnumGenerator.scala
@@ -1,0 +1,94 @@
+/**
+  * Copyright 2014 Dropbox, Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  * 
+  * This file has been modified by Snap, Inc.
+  */
+
+package djinni
+
+import djinni.ast.Record.DerivingType
+import djinni.ast._
+import djinni.generatorTools._
+import djinni.meta._
+import djinni.writer.IndentWriter
+
+import scala.collection.mutable
+
+class PythonEnumGenerator(spec: Spec) extends Generator(spec) {
+
+  var tripleq = "\"\"\""
+
+  override def generateEnum(origin: String, ident: Ident, doc: Doc, e: Enum) {
+    if (e.flags) {
+      return // Not Implemented
+    }
+
+    createFile(spec.pythonEnumOutFolder.get, idPython.file(ident) + ".py", (w: IndentWriter) => {
+      writeDoc(w, doc)
+
+      w.wl(s"from enum import Enum")
+      w.wl
+
+      w.wl(s"class ${idPython.ty(ident.name)}(Enum):").nested {
+        writeEnumOptions(w, e, idPython.enum, "=")
+        w.wl
+        w.wl("def __int__(self) -> int:").nested {
+          w.wl(s"return self.value[0]")
+        }
+        w.wl
+        w.wl("def __str__(self) -> str:").nested {
+          w.wl(s"return self.value[1]")
+        }
+      }
+
+      w.wl
+    })
+  }
+
+  /** Write the enum options for a Python Enum with support for C++ names.
+   * Instead of generating a normal enum with ordinal values, it handles both ordinal values and C++ names. This allows
+   * us to store the _name_ in resource files (tiles) and use the from_string to convert it back. This protects us from
+   * invalidation if the enum's ordering changes.
+   */
+  override def writeEnumOptions(w: IndentWriter, e: Enum, ident: IdentConverter, delim: String = "=") {
+    
+    var shift = 0
+    for (o <- normalEnumOptions(e)) {
+      w.wl(ident(o.ident.name) + s" $delim $shift, " + '"' + idCpp.enum(o.ident.name) + '"')
+      writeDoc(w, o.doc)
+      shift += 1
+    }
+  }
+
+  override def writeDoc(w: IndentWriter, doc: Doc) {
+    doc.lines.length match {
+      case 0 =>
+      case 1 =>
+        w.wl(tripleq + doc.lines.head+ tripleq)
+      case _ =>
+        w.wl(tripleq)
+        doc.lines.foreach (l => w.wl(s" *$l"))
+        w.wl(tripleq)
+    }
+  }
+
+  override def generateRecord(origin: String, ident: Ident, doc: Doc, params: Seq[TypeParam], r: Record, idl: Seq[TypeDecl]) {
+    return // Not Implemented
+  }
+
+  override def generateInterface(origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface) {
+    return // Not Implemented
+  }
+}


### PR DESCRIPTION
We want to start using SixOColors in the drawtiles, which are compiled by the Python package tileCompress. This meant two things:

- To protect against typos, we want Python support: I only implemented our specific use-case, i.e. non-flag enums.
- We will be storing references to this enum in resources that are shared between different versions of the app, so we cannot rely on their ordinal value.

We therefore implement two things:

- A Python generator that creates enums to expose both the (latest) ordinal value and the C++ name
- A C++ function to lookup enum values by name.

Relates to TransitApp/transitLib#8574.